### PR TITLE
Removing a DeadLock case in dining-philosophers.c

### DIFF
--- a/Process Synchronization/dining-philosophers.c
+++ b/Process Synchronization/dining-philosophers.c
@@ -18,10 +18,15 @@ void *thinkEatRepeat(int i)
 
 	printf("%d eating...\n",i+1 );
 	sleep(1);
-
-	pthread_mutex_unlock(&chopsticks[i]);
-	pthread_mutex_unlock(&chopsticks[(i+1)%n]);		
-
+	
+	if(i!=n){	
+		pthread_mutex_unlock(&chopsticks[i]);
+		pthread_mutex_unlock(&chopsticks[(i+1)%n]);		
+	}
+	else{	//It handles the case when all philosphers pick the chopstick to their right which will result in a deadlock
+		pthread_mutex_unlock(&chopsticks[i]);
+		pthread_mutex_unlock(&chopsticks[(i-1)%n]);		
+	}
 	printf("\t%d Finished eating\n", i+1);
 
 	return NULL;


### PR DESCRIPTION
The updated code handles the deadlock which occurs when all the philosophers pick the chopstick to their right or all of them pick their left ones occurring in a deadlock situation. :)